### PR TITLE
Renaming of Address dto model to QuoteAddress

### DIFF
--- a/VirtoCommerce.QuoteModule.Web/Converters/AddressConverter.cs
+++ b/VirtoCommerce.QuoteModule.Web/Converters/AddressConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -11,15 +11,15 @@ namespace VirtoCommerce.QuoteModule.Web.Converters
 {
 	public static class AddressConverter
 	{
-		public static webModel.Address ToWebModel(this Address address)
+		public static webModel.QuoteAddress ToWebModel(this Address address)
 		{
-			var retVal = new webModel.Address();
+			var retVal = new webModel.QuoteAddress();
 			retVal.InjectFrom(address);
             retVal.AddressType = address.AddressType;
 			return retVal;
 		}
 
-		public static Address ToCoreModel(this webModel.Address address)
+		public static Address ToCoreModel(this webModel.QuoteAddress address)
 		{
 			var retVal = new Address();
 			retVal.InjectFrom(address);

--- a/VirtoCommerce.QuoteModule.Web/Model/QuoteAddress.cs
+++ b/VirtoCommerce.QuoteModule.Web/Model/QuoteAddress.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -8,7 +8,7 @@ using VirtoCommerce.Domain.Commerce.Model;
 
 namespace VirtoCommerce.QuoteModule.Web.Model
 {
-	public class Address
+	public class QuoteAddress
 	{
 		[JsonConverter(typeof(StringEnumConverter))]
 		public AddressType AddressType { get; set; }

--- a/VirtoCommerce.QuoteModule.Web/Model/QuoteRequest.cs
+++ b/VirtoCommerce.QuoteModule.Web/Model/QuoteRequest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -95,7 +95,7 @@ namespace VirtoCommerce.QuoteModule.Web.Model
         /// Predefined shipment method used for delivery order created from current RFQ
         /// </summary>
 		public ShipmentMethod ShipmentMethod { get; set; }
-		public ICollection<Address> Addresses { get; set; }
+		public ICollection<QuoteAddress> Addresses { get; set; }
         /// <summary>
         /// RFQ items
         /// </summary>

--- a/VirtoCommerce.QuoteModule.Web/VirtoCommerce.QuoteModule.Web.csproj
+++ b/VirtoCommerce.QuoteModule.Web/VirtoCommerce.QuoteModule.Web.csproj
@@ -188,7 +188,7 @@
     <Compile Include="Converters\QuoteRequestConverter.cs" />
     <Compile Include="Converters\AddressConverter.cs" />
     <Compile Include="ExportImport\QuoteExportImport.cs" />
-    <Compile Include="Model\Address.cs" />
+    <Compile Include="Model\QuoteAddress.cs" />
     <Compile Include="Model\QuoteAttachment.cs" />
     <Compile Include="Model\QuoteItem.cs" />
     <Compile Include="Model\QuoteRequest.cs" />


### PR DESCRIPTION
Renaming of Address dto model to QuoteAddress to avoid conflict with Virto Commerce.Domain.Commerce.Model.Address on a swagger scheme.