### PR TITLE
VP-2557: Setting to set "Export/Import description" for quote module was not migrated

### DIFF
--- a/src/VirtoCommerce.QuoteModule.Web/Localizations/en.VirtoCommerce.Quote.json
+++ b/src/VirtoCommerce.QuoteModule.Web/Localizations/en.VirtoCommerce.Quote.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "quotes": {
     "main-menu-title": "Quotes",
     "blades": {
@@ -164,6 +164,11 @@
         "title": "Enable quotes",
         "description": "Flag to activate quotes in store"
       }
+    }
+  },
+  "module": {
+    "VirtoCommerce.Quote": {
+      "description": "Export/Import Request for quotes (RFQs)" 
     }
   }
 }

--- a/src/VirtoCommerce.QuoteModule.Web/Localizations/ru.VirtoCommerce.Quote.json
+++ b/src/VirtoCommerce.QuoteModule.Web/Localizations/ru.VirtoCommerce.Quote.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "quotes": {
     "main-menu-title": "Котировки",
     "blades": {
@@ -142,5 +142,10 @@
       "add-selected": "Добавить выбранные",
       "add-item": "Добавить позиции"
     }
-  }
+  },
+  "module": {
+    "VirtoCommerce.Quote": {
+      "description": "Экспорт/Импорт запросов котировок (RFQ)" 
+    }
+  } 
 }


### PR DESCRIPTION
### Problem
Localization key for export/import description is missed

### Solution
Add localization key

### Proposed of changes
Added localization key

![image](https://user-images.githubusercontent.com/15198683/92444813-b406b580-f1b3-11ea-8c8a-8ce0c17ecbc8.png)

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
