### PR TITLE
PT-7292: Remove redundant BuildServiceProvider from the module startup

### DIFF
--- a/src/VirtoCommerce.QuoteModule.Web/Module.cs
+++ b/src/VirtoCommerce.QuoteModule.Web/Module.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -33,10 +33,12 @@ namespace VirtoCommerce.QuoteModule.Web
 
         public void Initialize(IServiceCollection serviceCollection)
         {
-            var configuration = serviceCollection.BuildServiceProvider().GetRequiredService<IConfiguration>();
-            serviceCollection.AddTransient<IQuoteRepository, QuoteRepository>();
-            var connectionString = configuration.GetConnectionString("VirtoCommerce.Quote") ?? configuration.GetConnectionString("VirtoCommerce");
-            serviceCollection.AddDbContext<QuoteDbContext>(options => options.UseSqlServer(connectionString));
+            serviceCollection.AddDbContext<QuoteDbContext>((provider, options) =>
+            {
+                var configuration = provider.GetRequiredService<IConfiguration>();
+                options.UseSqlServer(configuration.GetConnectionString(ModuleInfo.Id) ?? configuration.GetConnectionString("VirtoCommerce"));
+            });
+
             serviceCollection.AddTransient<Func<IQuoteRepository>>(provider => () => provider.CreateScope().ServiceProvider.GetRequiredService<IQuoteRepository>());
             serviceCollection.AddTransient<IQuoteRequestService, QuoteRequestService>();
 

--- a/src/VirtoCommerce.QuoteModule.Web/Module.cs
+++ b/src/VirtoCommerce.QuoteModule.Web/Module.cs
@@ -39,6 +39,7 @@ namespace VirtoCommerce.QuoteModule.Web
                 options.UseSqlServer(configuration.GetConnectionString(ModuleInfo.Id) ?? configuration.GetConnectionString("VirtoCommerce"));
             });
 
+            serviceCollection.AddTransient<IQuoteRepository, QuoteRepository>();
             serviceCollection.AddTransient<Func<IQuoteRepository>>(provider => () => provider.CreateScope().ServiceProvider.GetRequiredService<IQuoteRepository>());
             serviceCollection.AddTransient<IQuoteRequestService, QuoteRequestService>();
 


### PR DESCRIPTION
## Description
Remove redundant BuildServiceProvider from the module startup
## References
### QA-test:
### Jira-link:


 https://virtocommerce.atlassian.net/browse/PT-7292
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Quote_3.202.0-pr-56.zip
