### PR TITLE
VCST-2258: Added GraphQL mutation for Quote DynamicProperties (#126)

### DIFF
--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteDynamicPropertiesCommand.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteDynamicPropertiesCommand.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Models;
+using VirtoCommerce.Xapi.Core.Schemas;
+
+namespace VirtoCommerce.QuoteModule.ExperienceApi.Commands;
+
+public class UpdateQuoteDynamicPropertiesCommand : QuoteCommand
+{
+    public List<DynamicPropertyValue> DynamicProperties { get; set; } = default!;
+}
+
+public class UpdateQuoteDynamicPropertiesCommandType : QuoteCommandType<UpdateQuoteDynamicPropertiesCommand>
+{
+    public UpdateQuoteDynamicPropertiesCommandType()
+    {
+        Field<NonNullGraphType<ListGraphType<InputDynamicPropertyValueType>>>(
+            "dynamicProperties",
+            "Dynamic properties"
+        );
+    }
+}

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteDynamicPropertiesCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteDynamicPropertiesCommandBuilder.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+
+namespace VirtoCommerce.QuoteModule.ExperienceApi.Commands;
+
+public class UpdateQuoteDynamicPropertiesCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
+    : QuoteCommandBuilder<UpdateQuoteDynamicPropertiesCommand, UpdateQuoteDynamicPropertiesCommandType>(
+        mediator,
+        authorizationService
+    )
+{
+    protected override string Name => "updateQuoteDynamicProperties";
+}

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteDynamicPropertiesCommandHandler.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteDynamicPropertiesCommandHandler.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.QuoteModule.Core.Models;
+using VirtoCommerce.QuoteModule.Core.Services;
+using VirtoCommerce.QuoteModule.ExperienceApi.Aggregates;
+using VirtoCommerce.Xapi.Core.Services;
+
+namespace VirtoCommerce.QuoteModule.ExperienceApi.Commands;
+
+public class UpdateQuoteDynamicPropertiesCommandHandler(
+    IQuoteRequestService quoteRequestService,
+    IQuoteAggregateRepository quoteAggregateRepository,
+    ISettingsManager settingsManager,
+    IDynamicPropertyUpdaterService dynamicPropertyUpdaterService
+)
+    : QuoteCommandHandler<UpdateQuoteDynamicPropertiesCommand>(
+        quoteRequestService,
+        quoteAggregateRepository,
+        settingsManager
+    )
+{
+    protected override async Task UpdateQuoteAsync(QuoteRequest quote, UpdateQuoteDynamicPropertiesCommand request)
+    {
+        await dynamicPropertyUpdaterService.UpdateDynamicPropertyValues(quote, request.DynamicProperties);
+    }
+
+    protected override void UpdateQuote(QuoteRequest quote, UpdateQuoteDynamicPropertiesCommand request)
+    {
+        // Empty implementation of obsolete abstract method
+    }
+}


### PR DESCRIPTION
## Description
Added the possibility to update quote dynamic properties through a GraphQL mutation

```
mutation {
  updateQuoteDynamicProperties(command:{
    quoteId:"{id}",
    dynamicProperties:[
      {
        name:"{propertyName}",
        value:"{value}",
        locale:"{locale}",
        cultureName:"{cultureName}"
      }
    ]
  }) {
    id
    # quote values
  }
}
``` 

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2258
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Quote_3.821.0-pr-127-f028.zip