### PR TITLE
VCST-5468: Resolve mediators per request

### DIFF
--- a/src/VirtoCommerce.QuoteModule.Core/VirtoCommerce.QuoteModule.Core.csproj
+++ b/src/VirtoCommerce.QuoteModule.Core/VirtoCommerce.QuoteModule.Core.csproj
@@ -15,8 +15,8 @@
     
     <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.TaxModule.Core" Version="3.1003.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.QuoteModule.Data.MySql/VirtoCommerce.QuoteModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.QuoteModule.Data.MySql/VirtoCommerce.QuoteModule.Data.MySql.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.QuoteModule.Data\VirtoCommerce.QuoteModule.Data.csproj" />

--- a/src/VirtoCommerce.QuoteModule.Data.PostgreSql/VirtoCommerce.QuoteModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.QuoteModule.Data.PostgreSql/VirtoCommerce.QuoteModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.QuoteModule.Data\VirtoCommerce.QuoteModule.Data.csproj" />

--- a/src/VirtoCommerce.QuoteModule.Data.SqlServer/VirtoCommerce.QuoteModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.QuoteModule.Data.SqlServer/VirtoCommerce.QuoteModule.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.QuoteModule.Data\VirtoCommerce.QuoteModule.Data.csproj" />

--- a/src/VirtoCommerce.QuoteModule.Data/VirtoCommerce.QuoteModule.Data.csproj
+++ b/src/VirtoCommerce.QuoteModule.Data/VirtoCommerce.QuoteModule.Data.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
     <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1007.10" />
     <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1006.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.QuoteModule.Core\VirtoCommerce.QuoteModule.Core.csproj" />

--- a/src/VirtoCommerce.QuoteModule.Data/VirtoCommerce.QuoteModule.Data.csproj
+++ b/src/VirtoCommerce.QuoteModule.Data/VirtoCommerce.QuoteModule.Data.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
     <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1006.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/AddQuoteAttachmentsCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/AddQuoteAttachmentsCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class AddQuoteAttachmentsCommandBuilder : QuoteCommandBuilder<AddQuoteAtt
 {
     protected override string Name => "AddQuoteAttachments";
 
+    public AddQuoteAttachmentsCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public AddQuoteAttachmentsCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/AddQuoteItemsCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/AddQuoteItemsCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,7 +8,14 @@ public class AddQuoteItemsCommandBuilder : QuoteCommandBuilder<AddQuoteItemsComm
 {
     protected override string Name => "addQuoteItems";
 
-    public AddQuoteItemsCommandBuilder(IMediator mediator, IAuthorizationService authorizationService) : base(mediator, authorizationService)
+    public AddQuoteItemsCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public AddQuoteItemsCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/ApproveQuoteCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/ApproveQuoteCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.Xapi.Core.BaseQueries;
@@ -10,8 +11,14 @@ public class ApproveQuoteCommandBuilder : CommandBuilder<ApproveQuoteCommand, Ap
 {
     protected override string Name => "approveQuoteRequest";
 
+    public ApproveQuoteCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public ApproveQuoteCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/CancelQuoteCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/CancelQuoteCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class CancelQuoteCommandBuilder : QuoteCommandBuilder<CancelQuoteCommand,
 {
     protected override string Name => "cancelQuoteRequest";
 
+    public CancelQuoteCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public CancelQuoteCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/ChangeQuoteCommentCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/ChangeQuoteCommentCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class ChangeQuoteCommentCommandBuilder : QuoteCommandBuilder<ChangeQuoteC
 {
     protected override string Name => "changeQuoteComment";
 
+    public ChangeQuoteCommentCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public ChangeQuoteCommentCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/ChangeQuoteItemQuantityCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/ChangeQuoteItemQuantityCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class ChangeQuoteItemQuantityCommandBuilder : QuoteCommandBuilder<ChangeQ
 {
     protected override string Name => "changeQuoteItemQuantity";
 
+    public ChangeQuoteItemQuantityCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public ChangeQuoteItemQuantityCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/CreateQuoteCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/CreateQuoteCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
@@ -14,8 +15,14 @@ public class CreateQuoteCommandBuilder : CommandBuilder<CreateQuoteCommand, Quot
 {
     protected override string Name => "CreateQuote";
 
+    public CreateQuoteCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public CreateQuoteCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/CreateQuoteFromCartCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/CreateQuoteFromCartCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
@@ -5,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.QuoteModule.ExperienceApi.Aggregates;
 using VirtoCommerce.QuoteModule.ExperienceApi.Schemas;
 using VirtoCommerce.Xapi.Core.BaseQueries;
+using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.XCart.Core.Queries;
 using VirtoCommerce.XCart.Data.Authorization;
 
@@ -12,14 +14,17 @@ namespace VirtoCommerce.QuoteModule.ExperienceApi.Commands;
 
 public class CreateQuoteFromCartCommandBuilder : CommandBuilder<CreateQuoteFromCartCommand, QuoteAggregate, CreateQuoteFromCartCommandType, QuoteType>
 {
-    private readonly IMediator _mediator;
-
     protected override string Name => "createQuoteFromCart";
 
-    public CreateQuoteFromCartCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+    public CreateQuoteFromCartCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
     {
-        _mediator = mediator;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public CreateQuoteFromCartCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
+        : this(authorizationService)
+    {
     }
 
     protected override async Task BeforeMediatorSend(IResolveFieldContext<object> context, CreateQuoteFromCartCommand request)
@@ -30,7 +35,7 @@ public class CreateQuoteFromCartCommandBuilder : CommandBuilder<CreateQuoteFromC
 
     protected virtual async Task CheckCanAccessCart(IResolveFieldContext context, string cartId)
     {
-        var cart = await _mediator.Send(new GetCartByIdQuery { CartId = cartId });
+        var cart = await context.GetMediator().Send(new GetCartByIdQuery { CartId = cartId });
         await Authorize(context, cart?.Cart, new CanAccessCartAuthorizationRequirement());
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/DeclineQuoteCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/DeclineQuoteCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class DeclineQuoteCommandBuilder : QuoteCommandBuilder<DeclineQuoteComman
 {
     protected override string Name => "declineQuoteRequest";
 
+    public DeclineQuoteCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public DeclineQuoteCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/DeleteQuoteAttachmentsCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/DeleteQuoteAttachmentsCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class DeleteQuoteAttachmentsCommandBuilder : QuoteCommandBuilder<DeleteQu
 {
     protected override string Name => "DeleteQuoteAttachments";
 
+    public DeleteQuoteAttachmentsCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public DeleteQuoteAttachmentsCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/QuoteCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/QuoteCommandBuilder.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.Xapi.Core.BaseQueries;
+using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.QuoteModule.ExperienceApi.Aggregates;
 using VirtoCommerce.QuoteModule.ExperienceApi.Authorization;
 using VirtoCommerce.QuoteModule.ExperienceApi.Queries;
@@ -14,12 +16,15 @@ public abstract class QuoteCommandBuilder<TCommand, TCommandGraphType> : Command
     where TCommand : QuoteCommand
     where TCommandGraphType : QuoteCommandType<TCommand>
 {
-    private readonly IMediator _mediator;
-
-    protected QuoteCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+    protected QuoteCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
     {
-        _mediator = mediator;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    protected QuoteCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
+        : this(authorizationService)
+    {
     }
 
     protected override async Task BeforeMediatorSend(IResolveFieldContext<object> context, TCommand request)
@@ -30,7 +35,7 @@ public abstract class QuoteCommandBuilder<TCommand, TCommandGraphType> : Command
 
     protected virtual async Task CheckCanAccessQuote(IResolveFieldContext<object> context, string quoteId)
     {
-        var quote = await _mediator.Send(new QuoteQuery { Id = quoteId });
+        var quote = await context.GetMediator().Send(new QuoteQuery { Id = quoteId });
         await Authorize(context, quote, new QuoteAuthorizationRequirement());
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/RemoveQuoteItemCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/RemoveQuoteItemCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class RemoveQuoteItemCommandBuilder : QuoteCommandBuilder<RemoveQuoteItem
 {
     protected override string Name => "removeQuoteItem";
 
+    public RemoveQuoteItemCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public RemoveQuoteItemCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/SubmitQuoteCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/SubmitQuoteCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class SubmitQuoteCommandBuilder : QuoteCommandBuilder<SubmitQuoteCommand,
 {
     protected override string Name => "submitQuoteRequest";
 
+    public SubmitQuoteCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public SubmitQuoteCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteAddressesCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteAddressesCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class UpdateQuoteAddressesCommandBuilder : QuoteCommandBuilder<UpdateQuot
 {
     protected override string Name => "updateQuoteAddresses";
 
+    public UpdateQuoteAddressesCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public UpdateQuoteAddressesCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteAttachmentsCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteAttachmentsCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
@@ -7,8 +8,14 @@ public class UpdateQuoteAttachmentsCommandBuilder : QuoteCommandBuilder<UpdateQu
 {
     protected override string Name => "UpdateQuoteAttachments";
 
+    public UpdateQuoteAttachmentsCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public UpdateQuoteAttachmentsCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteDynamicPropertiesCommandBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Commands/UpdateQuoteDynamicPropertiesCommandBuilder.cs
@@ -1,13 +1,21 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 
 namespace VirtoCommerce.QuoteModule.ExperienceApi.Commands;
 
-public class UpdateQuoteDynamicPropertiesCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-    : QuoteCommandBuilder<UpdateQuoteDynamicPropertiesCommand, UpdateQuoteDynamicPropertiesCommandType>(
-        mediator,
-        authorizationService
-    )
+public class UpdateQuoteDynamicPropertiesCommandBuilder : QuoteCommandBuilder<UpdateQuoteDynamicPropertiesCommand, UpdateQuoteDynamicPropertiesCommandType>
 {
     protected override string Name => "updateQuoteDynamicProperties";
+
+    public UpdateQuoteDynamicPropertiesCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public UpdateQuoteDynamicPropertiesCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
+        : this(authorizationService)
+    {
+    }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Queries/QuoteAttachmentOptionsQueryBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Queries/QuoteAttachmentOptionsQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.Xapi.Core.BaseQueries;
@@ -10,8 +11,14 @@ public class QuoteAttachmentOptionsQueryBuilder : QueryBuilder<QuoteAttachmentOp
 {
     protected override string Name => "QuoteAttachmentOptions";
 
+    public QuoteAttachmentOptionsQueryBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public QuoteAttachmentOptionsQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Queries/QuoteQueryBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Queries/QuoteQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
@@ -14,8 +15,14 @@ public class QuoteQueryBuilder : QueryBuilder<QuoteQuery, QuoteAggregate, QuoteT
 {
     protected override string Name => "quote";
 
+    public QuoteQueryBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public QuoteQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Queries/QuotesQueryBuilder.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Queries/QuotesQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
@@ -14,8 +15,14 @@ public class QuotesQueryBuilder : SearchQueryBuilder<QuotesQuery, QuoteAggregate
 {
     protected override string Name => "quotes";
 
+    public QuotesQueryBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public QuotesQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/Schemas/QuoteItemType.cs
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/Schemas/QuoteItemType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -20,7 +21,7 @@ namespace VirtoCommerce.QuoteModule.ExperienceApi.Schemas;
 
 public class QuoteItemType : ExtendableGraphType<QuoteItemAggregate>
 {
-    public QuoteItemType(IMediator mediator, IDataLoaderContextAccessor dataLoader)
+    public QuoteItemType(IDataLoaderContextAccessor dataLoader)
     {
         Field(x => x.Model.Id, nullable: false);
         Field(x => x.Model.Sku, nullable: true);
@@ -65,7 +66,7 @@ public class QuoteItemType : ExtendableGraphType<QuoteItemAggregate>
                     context.UserContext.TryAdd("store", quoteAggregate.Store);
                     context.UserContext.TryAdd("cultureName", cultureName);
 
-                    var response = await mediator.Send(request);
+                    var response = await context.GetMediator().Send(request);
 
                     return response.Products.ToDictionary(x => x.Id);
                 });
@@ -82,5 +83,11 @@ public class QuoteItemType : ExtendableGraphType<QuoteItemAggregate>
             "configurationItems",
             "Configuration items for configurable product",
             resolve: context => context.Source.Model?.ConfigurationItems ?? []);
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public QuoteItemType(IMediator mediator, IDataLoaderContextAccessor dataLoader)
+        : this(dataLoader)
+    {
     }
 }

--- a/src/VirtoCommerce.QuoteModule.ExperienceApi/VirtoCommerce.QuoteModule.ExperienceApi.csproj
+++ b/src/VirtoCommerce.QuoteModule.ExperienceApi/VirtoCommerce.QuoteModule.ExperienceApi.csproj
@@ -10,10 +10,10 @@
     
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Data" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
     <PackageReference Include="VirtoCommerce.XCart.Data" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1011.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1010.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.QuoteModule.Core\VirtoCommerce.QuoteModule.Core.csproj" />

--- a/src/VirtoCommerce.QuoteModule.Web/ExportImport/QuoteExportImport.cs
+++ b/src/VirtoCommerce.QuoteModule.Web/ExportImport/QuoteExportImport.cs
@@ -32,8 +32,8 @@ namespace VirtoCommerce.QuoteModule.Web.ExportImport
             using (var sw = new StreamWriter(outStream, System.Text.Encoding.UTF8))
             using (var writer = new JsonTextWriter(sw))
             {
-                await writer.WriteStartObjectAsync();
-                await writer.WritePropertyNameAsync("QuoteRequests");
+                await writer.WriteStartObjectAsync(cancellationToken);
+                await writer.WritePropertyNameAsync("QuoteRequests", cancellationToken);
 
                 await writer.SerializeArrayWithPagingAsync(_serializer, _batchSize, async (skip, take) =>
                         (GenericSearchResult<QuoteRequest>)await _quoteRequestService.SearchAsync(new QuoteRequestSearchCriteria { Skip = skip, Take = take })
@@ -43,8 +43,8 @@ namespace VirtoCommerce.QuoteModule.Web.ExportImport
                         progressCallback(progressInfo);
                     }, cancellationToken);
 
-                await writer.WriteEndObjectAsync();
-                await writer.FlushAsync();
+                await writer.WriteEndObjectAsync(cancellationToken);
+                await writer.FlushAsync(cancellationToken);
             }
         }
 
@@ -58,7 +58,7 @@ namespace VirtoCommerce.QuoteModule.Web.ExportImport
             using (var streamReader = new StreamReader(inputStream))
             using (var reader = new JsonTextReader(streamReader))
             {
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync(cancellationToken))
                 {
                     if (reader.TokenType != JsonToken.PropertyName)
                     {

--- a/src/VirtoCommerce.QuoteModule.Web/ExportImport/QuoteExportImport.cs
+++ b/src/VirtoCommerce.QuoteModule.Web/ExportImport/QuoteExportImport.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using VirtoCommerce.Platform.Core.Common;
@@ -22,7 +23,7 @@ namespace VirtoCommerce.QuoteModule.Web.ExportImport
             _serializer = serializer;
         }
 
-        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var progressInfo = new ExportImportProgressInfo { Description = "loading data..." };
@@ -47,7 +48,7 @@ namespace VirtoCommerce.QuoteModule.Web.ExportImport
             }
         }
 
-        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.QuoteModule.Web/Module.cs
+++ b/src/VirtoCommerce.QuoteModule.Web/Module.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.MicrosoftDI;
@@ -128,13 +129,13 @@ namespace VirtoCommerce.QuoteModule.Web
             // Method intentionally left empty.
         }
 
-        public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<QuoteExportImport>().DoExportAsync(outStream,
                 progressCallback, cancellationToken);
         }
 
-        public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<QuoteExportImport>().DoImportAsync(inputStream,
               progressCallback, cancellationToken);

--- a/src/VirtoCommerce.QuoteModule.Web/module.manifest
+++ b/src/VirtoCommerce.QuoteModule.Web/module.manifest
@@ -4,21 +4,21 @@
   <version>3.1002.0</version>
   <version-tag />
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
     <dependency id="VirtoCommerce.Cart" version="3.1000.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1010.0" />
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
     <dependency id="VirtoCommerce.Shipping" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Tax" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1006.0" />
+    <dependency id="VirtoCommerce.Tax" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
     <dependency id="VirtoCommerce.XCart" version="3.1000.0" />
-    <dependency id="VirtoCommerce.XCatalog" version="3.1000.0" />
+    <dependency id="VirtoCommerce.XCatalog" version="3.1011.0" />
   </dependencies>
 
   <title>Quotes</title>


### PR DESCRIPTION
## Description

Quote Experience API GraphQL schema types and builders are singleton schema components. This change upgrades XApi to `3.1015.0` and resolves mediation through the active request context rather than retaining a root-scoped mediator.

All Quote command/query builders and QuoteItemType use mediator-free constructors or context-first resolver helpers; obsolete compatibility constructors remain. Direct dependencies and manifest entries are aligned with the resolved XApi 3.1015 dependency graph.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Quote_3.1002.0-alpha.510-vcst-5468.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization pre-checks and all quote GraphQL commands/queries via mediator resolution; behavior should match prior logic but incorrect scoping could affect request-scoped handlers. Broad dependency upgrades add integration risk across the platform stack.
> 
> **Overview**
> Quote Experience API GraphQL **builders and `QuoteItemType` no longer take a root-scoped `IMediator`**. They use **`IAuthorizationService`-only constructors** and resolve the mediator at runtime via **`context.GetMediator()`** (e.g. quote access checks, cart lookup, product loading). **`IMediator` constructors remain but are marked `[Obsolete]` (VC0015)** for compatibility.
> 
> **Platform and module dependencies are bumped** (notably **XApi `3.1015.0`**, **Platform `3.1039.0`**, and aligned Core/Store/Tax/XCatalog/Customer versions) in **csproj** files and **`module.manifest`**.
> 
> **Export/import** follows the updated platform API: **`ICancellationToken` → `CancellationToken`** on module and `QuoteExportImport`, with cancellation tokens passed into **JsonTextWriter/JsonTextReader** async calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f240b7192299d61fc5f67ca1768e234cd0c1c37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->